### PR TITLE
OvmfPkg/PlatformPei: Use fw_cfg for platform id

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/X86Virt.h
+++ b/OvmfPkg/Include/IndustryStandard/X86Virt.h
@@ -1,0 +1,43 @@
+/** @file
+  Various register numbers and value bits for the x86 virt platform
+  Copyright (C) 2018, Intel Corporation. All rights reserved
+
+  This program and the accompanying materials are licensed and made available
+  under the terms and conditions of the BSD License which accompanies this
+  distribution.   The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS, WITHOUT
+  WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+**/
+
+#ifndef __X86_VIRT_H__
+#define __X86_VIRT_H__
+
+//
+// Device ID for emulated PCI host bridge used on virt platform
+//
+#define VIRT_QEMU_DEVICE_ID 0x8
+
+//
+// SLP_TYP and SLP_EN values for HW-reduced ACPI used on virt platform
+//
+#define ACPI_REDUCED_SLEEP_EN   (1<<5)
+#define ACPI_REDUCED_SLEEP_TYPE 5 
+
+//
+// RESET_VALUE for HW-reduced ACPI used on virt platform
+//
+#define ACPI_REDUCED_RESET_VALUE 4
+
+//
+// Values for sleep control ioport address used on virt platform
+//
+#define VIRT_SLEEP_CONTROL_ADDRESS 0x3B0
+
+//
+// Values for reset ioport address used on virt platform
+//
+#define VIRT_RESET_ADDRESS 0x3C0
+
+#endif

--- a/OvmfPkg/Include/OvmfPlatforms.h
+++ b/OvmfPkg/Include/OvmfPlatforms.h
@@ -20,6 +20,7 @@
 #include <IndustryStandard/Pci22.h>
 #include <IndustryStandard/Q35MchIch9.h>
 #include <IndustryStandard/I440FxPiix4.h>
+#include <IndustryStandard/X86Virt.h>
 
 //
 // OVMF Host Bridge DID Address
@@ -44,28 +45,15 @@
 #define ACPI_TIMER_OFFSET 0x8
 
 //
-// Device ID for emulated PCI host bridge used on virt platform
+// QEMU defined machine ids
 //
-#define QEMU_GPEX_DEVICE_ID 0x8
+enum {
+        X86_I440FX = 1,
+        X86_Q35,
+        X86_ISAPC,
+        X86_XENFV,
+        X86_XENPV,
+        X86_VIRT,
+};
 
-//
-// SLP_TYP and SLP_EN values for HW-reduced ACPI used on virt platform
-//
-#define ACPI_REDUCED_SLEEP_EN   (1<<5)
-#define ACPI_REDUCED_SLEEP_TYPE 5 
-
-//
-// RESET_VALUE for HW-reduced ACPI used on virt platform
-//
-#define ACPI_REDUCED_RESET_VALUE 4
-
-//
-// Values for sleep control ioport address used on virt platform
-//
-#define VIRT_SLEEP_CONTROL_ADDRESS 0x3B0
-
-//
-// Values for reset ioport address used on virt platform
-//
-#define VIRT_RESET_ADDRESS 0x3C0
 #endif

--- a/OvmfPkg/Library/DxePciLibI440FxQ35/PciLib.c
+++ b/OvmfPkg/Library/DxePciLibI440FxQ35/PciLib.c
@@ -44,7 +44,7 @@ InitializeConfigAccessMethod (
 
   /* Both Q35 and Virt support PCI Express */
   mRunningOnPciExpress = ((hostBridgeId == INTEL_Q35_MCH_DEVICE_ID) ||
-                         (hostBridgeId == QEMU_GPEX_DEVICE_ID));
+                         (hostBridgeId == VIRT_QEMU_DEVICE_ID));
 
   return RETURN_SUCCESS;
 }

--- a/OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -157,7 +157,7 @@ InitRootBridge (
   hostBridgeId = PcdGet16(PcdOvmfHostBridgePciDevId);
 
   RootBus->NoExtendedConfigSpace = ((hostBridgeId != INTEL_Q35_MCH_DEVICE_ID) &&
-	                            (hostBridgeId != QEMU_GPEX_DEVICE_ID));
+	                            (hostBridgeId != VIRT_QEMU_DEVICE_ID));
 
   DevicePath = AllocateCopyPool (sizeof mRootBridgeDevicePathTemplate,
                  &mRootBridgeDevicePathTemplate);

--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1212,7 +1212,7 @@ PciAcpiInitialization (
       PciWrite8 (PCI_LIB_ADDRESS (0, 0x1f, 0, 0x6a), 0x0b); // G
       PciWrite8 (PCI_LIB_ADDRESS (0, 0x1f, 0, 0x6b), 0x0b); // H
       break;
-    case QEMU_GPEX_DEVICE_ID:
+    case VIRT_QEMU_DEVICE_ID:
       DEBUG((EFI_D_INFO, "TODO: Skipping PCI ACPI initialization\n"));
       return;
     default:

--- a/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -102,7 +102,7 @@ ResetWarm (
 
   HostBridgeDevId = PciRead16 (OVMF_HOSTBRIDGE_DID);
   switch (HostBridgeDevId) {
-  case QEMU_GPEX_DEVICE_ID:
+  case VIRT_QEMU_DEVICE_ID:
     IoWrite8 (VIRT_RESET_ADDRESS, ACPI_REDUCED_RESET_VALUE);
     CpuDeadLoop ();
     break;
@@ -130,7 +130,7 @@ ResetShutdown (
 
   HostBridgeDevId = PciRead16 (OVMF_HOSTBRIDGE_DID);
   switch (HostBridgeDevId) {
-  case QEMU_GPEX_DEVICE_ID:
+  case VIRT_QEMU_DEVICE_ID:
     AcpiReducedSleepControl (ACPI_REDUCED_SLEEP_TYPE);
     break;
   default:

--- a/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
+++ b/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
@@ -798,7 +798,7 @@ DriverInitialize (
   UINT16 hostBridgeId = PcdGet16 (PcdOvmfHostBridgePciDevId);
 
   mPciExtConfSpaceSupported = ((hostBridgeId == INTEL_Q35_MCH_DEVICE_ID) ||
-	                             (hostBridgeId == QEMU_GPEX_DEVICE_ID));
+	                             (hostBridgeId == VIRT_QEMU_DEVICE_ID));
   mPciHotPlugInit.GetRootHpcList = GetRootHpcList;
   mPciHotPlugInit.InitializeRootHpc = InitializeRootHpc;
   mPciHotPlugInit.GetResourcePadding = GetResourcePadding;


### PR DESCRIPTION
Firmware (and OS) today uses the device id of the host bridge
as a means of determining the platform on which it is running.
Use fw_cfg if available instead obtain this information. This
will allow it to be decoupled from PCI (as it should be) in the
case of a virtual platform.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>