### PR TITLE
OvmfPkg/PciHotPlugInitDxe: Use PCI Expresss MMIO for virt platform

### DIFF
--- a/OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
+++ b/OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
@@ -45,3 +45,4 @@
 
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfMachineId

--- a/OvmfPkg/Library/DxePciLibI440FxQ35/PciLib.c
+++ b/OvmfPkg/Library/DxePciLibI440FxQ35/PciLib.c
@@ -30,8 +30,9 @@
 #include <Library/PciCf8Lib.h>
 #include <Library/PciExpressLib.h>
 #include <Library/PcdLib.h>
+#include "OvmfPlatforms.h"
 
-STATIC BOOLEAN mRunningOnQ35;
+STATIC BOOLEAN mRunningOnPciExpress;
 
 RETURN_STATUS
 EFIAPI
@@ -39,8 +40,12 @@ InitializeConfigAccessMethod (
   VOID
   )
 {
-  mRunningOnQ35 = (PcdGet16 (PcdOvmfHostBridgePciDevId) ==
-                   INTEL_Q35_MCH_DEVICE_ID);
+  UINT16 hostBridgeId = PcdGet16 (PcdOvmfHostBridgePciDevId);
+
+  /* Both Q35 and Virt support PCI Express */
+  mRunningOnPciExpress = ((hostBridgeId == INTEL_Q35_MCH_DEVICE_ID) ||
+                         (hostBridgeId == VIRT_QEMU_DEVICE_ID));
+
   return RETURN_SUCCESS;
 }
 
@@ -71,7 +76,7 @@ PciRegisterForRuntimeAccess (
   IN UINTN  Address
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressRegisterForRuntimeAccess (Address) :
          PciCf8RegisterForRuntimeAccess (Address);
 }
@@ -97,7 +102,7 @@ PciRead8 (
   IN      UINTN                     Address
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressRead8 (Address) :
          PciCf8Read8 (Address);
 }
@@ -125,7 +130,7 @@ PciWrite8 (
   IN      UINT8                     Value
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressWrite8 (Address, Value) :
          PciCf8Write8 (Address, Value);
 }
@@ -157,7 +162,7 @@ PciOr8 (
   IN      UINT8                     OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressOr8 (Address, OrData) :
          PciCf8Or8 (Address, OrData);
 }
@@ -189,7 +194,7 @@ PciAnd8 (
   IN      UINT8                     AndData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressAnd8 (Address, AndData) :
          PciCf8And8 (Address, AndData);
 }
@@ -224,7 +229,7 @@ PciAndThenOr8 (
   IN      UINT8                     OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressAndThenOr8 (Address, AndData, OrData) :
          PciCf8AndThenOr8 (Address, AndData, OrData);
 }
@@ -258,7 +263,7 @@ PciBitFieldRead8 (
   IN      UINTN                     EndBit
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldRead8 (Address, StartBit, EndBit) :
          PciCf8BitFieldRead8 (Address, StartBit, EndBit);
 }
@@ -296,7 +301,7 @@ PciBitFieldWrite8 (
   IN      UINT8                     Value
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldWrite8 (Address, StartBit, EndBit, Value) :
          PciCf8BitFieldWrite8 (Address, StartBit, EndBit, Value);
 }
@@ -337,7 +342,7 @@ PciBitFieldOr8 (
   IN      UINT8                     OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldOr8 (Address, StartBit, EndBit, OrData) :
          PciCf8BitFieldOr8 (Address, StartBit, EndBit, OrData);
 }
@@ -378,7 +383,7 @@ PciBitFieldAnd8 (
   IN      UINT8                     AndData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldAnd8 (Address, StartBit, EndBit, AndData) :
          PciCf8BitFieldAnd8 (Address, StartBit, EndBit, AndData);
 }
@@ -424,7 +429,7 @@ PciBitFieldAndThenOr8 (
   IN      UINT8                     OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldAndThenOr8 (Address, StartBit, EndBit, AndData, OrData) :
          PciCf8BitFieldAndThenOr8 (Address, StartBit, EndBit, AndData, OrData);
 }
@@ -451,7 +456,7 @@ PciRead16 (
   IN      UINTN                     Address
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressRead16 (Address) :
          PciCf8Read16 (Address);
 }
@@ -480,7 +485,7 @@ PciWrite16 (
   IN      UINT16                    Value
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressWrite16 (Address, Value) :
          PciCf8Write16 (Address, Value);
 }
@@ -513,7 +518,7 @@ PciOr16 (
   IN      UINT16                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressOr16 (Address, OrData) :
          PciCf8Or16 (Address, OrData);
 }
@@ -546,7 +551,7 @@ PciAnd16 (
   IN      UINT16                    AndData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressAnd16 (Address, AndData) :
          PciCf8And16 (Address, AndData);
 }
@@ -582,7 +587,7 @@ PciAndThenOr16 (
   IN      UINT16                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressAndThenOr16 (Address, AndData, OrData) :
          PciCf8AndThenOr16 (Address, AndData, OrData);
 }
@@ -617,7 +622,7 @@ PciBitFieldRead16 (
   IN      UINTN                     EndBit
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldRead16 (Address, StartBit, EndBit) :
          PciCf8BitFieldRead16 (Address, StartBit, EndBit);
 }
@@ -656,7 +661,7 @@ PciBitFieldWrite16 (
   IN      UINT16                    Value
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldWrite16 (Address, StartBit, EndBit, Value) :
          PciCf8BitFieldWrite16 (Address, StartBit, EndBit, Value);
 }
@@ -698,7 +703,7 @@ PciBitFieldOr16 (
   IN      UINT16                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldOr16 (Address, StartBit, EndBit, OrData) :
          PciCf8BitFieldOr16 (Address, StartBit, EndBit, OrData);
 }
@@ -740,7 +745,7 @@ PciBitFieldAnd16 (
   IN      UINT16                    AndData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldAnd16 (Address, StartBit, EndBit, AndData) :
          PciCf8BitFieldAnd16 (Address, StartBit, EndBit, AndData);
 }
@@ -787,7 +792,7 @@ PciBitFieldAndThenOr16 (
   IN      UINT16                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldAndThenOr16 (Address, StartBit, EndBit, AndData, OrData) :
          PciCf8BitFieldAndThenOr16 (Address, StartBit, EndBit, AndData, OrData);
 }
@@ -814,7 +819,7 @@ PciRead32 (
   IN      UINTN                     Address
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressRead32 (Address) :
          PciCf8Read32 (Address);
 }
@@ -843,7 +848,7 @@ PciWrite32 (
   IN      UINT32                    Value
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressWrite32 (Address, Value) :
          PciCf8Write32 (Address, Value);
 }
@@ -876,7 +881,7 @@ PciOr32 (
   IN      UINT32                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressOr32 (Address, OrData) :
          PciCf8Or32 (Address, OrData);
 }
@@ -909,7 +914,7 @@ PciAnd32 (
   IN      UINT32                    AndData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressAnd32 (Address, AndData) :
          PciCf8And32 (Address, AndData);
 }
@@ -945,7 +950,7 @@ PciAndThenOr32 (
   IN      UINT32                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressAndThenOr32 (Address, AndData, OrData) :
          PciCf8AndThenOr32 (Address, AndData, OrData);
 }
@@ -980,7 +985,7 @@ PciBitFieldRead32 (
   IN      UINTN                     EndBit
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldRead32 (Address, StartBit, EndBit) :
          PciCf8BitFieldRead32 (Address, StartBit, EndBit);
 }
@@ -1019,7 +1024,7 @@ PciBitFieldWrite32 (
   IN      UINT32                    Value
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldWrite32 (Address, StartBit, EndBit, Value) :
          PciCf8BitFieldWrite32 (Address, StartBit, EndBit, Value);
 }
@@ -1061,7 +1066,7 @@ PciBitFieldOr32 (
   IN      UINT32                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldOr32 (Address, StartBit, EndBit, OrData) :
          PciCf8BitFieldOr32 (Address, StartBit, EndBit, OrData);
 }
@@ -1103,7 +1108,7 @@ PciBitFieldAnd32 (
   IN      UINT32                    AndData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldAnd32 (Address, StartBit, EndBit, AndData) :
          PciCf8BitFieldAnd32 (Address, StartBit, EndBit, AndData);
 }
@@ -1150,7 +1155,7 @@ PciBitFieldAndThenOr32 (
   IN      UINT32                    OrData
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressBitFieldAndThenOr32 (Address, StartBit, EndBit, AndData, OrData) :
          PciCf8BitFieldAndThenOr32 (Address, StartBit, EndBit, AndData, OrData);
 }
@@ -1186,7 +1191,7 @@ PciReadBuffer (
   OUT     VOID                      *Buffer
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressReadBuffer (StartAddress, Size, Buffer) :
          PciCf8ReadBuffer (StartAddress, Size, Buffer);
 }
@@ -1223,7 +1228,7 @@ PciWriteBuffer (
   IN      VOID                      *Buffer
   )
 {
-  return mRunningOnQ35 ?
+  return mRunningOnPciExpress ?
          PciExpressWriteBuffer (StartAddress, Size, Buffer) :
          PciCf8WriteBuffer (StartAddress, Size, Buffer);
 }

--- a/OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/OvmfPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -29,6 +29,7 @@
 #include <Library/PciLib.h>
 #include <Library/QemuFwCfgLib.h>
 #include "PciHostBridge.h"
+#include "OvmfPlatforms.h"
 
 
 #pragma pack(1)
@@ -130,6 +131,7 @@ InitRootBridge (
   )
 {
   OVMF_PCI_ROOT_BRIDGE_DEVICE_PATH *DevicePath;
+  UINT16 hostBridgeId;
 
   //
   // Be safe if other fields are added to PCI_ROOT_BRIDGE later.
@@ -152,8 +154,10 @@ InitRootBridge (
   CopyMem (&RootBus->PMem, PMem, sizeof (*PMem));
   CopyMem (&RootBus->PMemAbove4G, PMemAbove4G, sizeof (*PMemAbove4G));
 
-  RootBus->NoExtendedConfigSpace = (PcdGet16 (PcdOvmfHostBridgePciDevId) !=
-                                    INTEL_Q35_MCH_DEVICE_ID);
+  hostBridgeId = PcdGet16(PcdOvmfHostBridgePciDevId);
+
+  RootBus->NoExtendedConfigSpace = ((hostBridgeId != INTEL_Q35_MCH_DEVICE_ID) &&
+	                            (hostBridgeId != VIRT_QEMU_DEVICE_ID));
 
   DevicePath = AllocateCopyPool (sizeof mRootBridgeDevicePathTemplate,
                  &mRootBridgeDevicePathTemplate);

--- a/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -18,9 +18,24 @@
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>
 #include <Library/TimerLib.h>
+#include <Library/PcdLib.h>
 #include <OvmfPlatforms.h>
 
-#include <OvmfPlatforms.h>
+#include "OvmfPlatforms.h"
+
+static UINT16 mHostBridgeDevId;
+
+RETURN_STATUS
+EFIAPI
+ResetSystemLibConstructor (
+  VOID
+  )
+{
+  mHostBridgeDevId = PcdGet16 (PcdOvmfHostBridgePciDevId);
+
+  return RETURN_SUCCESS;
+}
+
 
 VOID
 AcpiPmControl (
@@ -28,13 +43,11 @@ AcpiPmControl (
   )
 {
   UINT16 AcpiPmBaseAddress;
-  UINT16 HostBridgeDevId;
 
   ASSERT (SuspendType < 6);
 
   AcpiPmBaseAddress = 0;
-  HostBridgeDevId = PciRead16 (OVMF_HOSTBRIDGE_DID);
-  switch (HostBridgeDevId) {
+  switch (mHostBridgeDevId) {
   case INTEL_82441_DEVICE_ID:
     AcpiPmBaseAddress = PIIX4_PMBA_VALUE;
     break;
@@ -98,10 +111,8 @@ ResetWarm (
   VOID
   )
 {
-  UINT16 HostBridgeDevId;
 
-  HostBridgeDevId = PciRead16 (OVMF_HOSTBRIDGE_DID);
-  switch (HostBridgeDevId) {
+  switch (mHostBridgeDevId) {
   case VIRT_QEMU_DEVICE_ID:
     IoWrite8 (VIRT_RESET_ADDRESS, ACPI_REDUCED_RESET_VALUE);
     CpuDeadLoop ();
@@ -126,10 +137,8 @@ ResetShutdown (
   VOID
   )
 {
-  UINT16 HostBridgeDevId;
 
-  HostBridgeDevId = PciRead16 (OVMF_HOSTBRIDGE_DID);
-  switch (HostBridgeDevId) {
+  switch (mHostBridgeDevId) {
   case VIRT_QEMU_DEVICE_ID:
     AcpiReducedSleepControl (ACPI_REDUCED_SLEEP_TYPE);
     break;

--- a/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -23,7 +23,7 @@
 
 #include "OvmfPlatforms.h"
 
-static UINT16 mHostBridgeDevId;
+static UINT16 mOvmfMachineId;
 
 RETURN_STATUS
 EFIAPI
@@ -31,7 +31,7 @@ ResetSystemLibConstructor (
   VOID
   )
 {
-  mHostBridgeDevId = PcdGet16 (PcdOvmfHostBridgePciDevId);
+  mOvmfMachineId = PcdGet16 (PcdOvmfMachineId);
 
   return RETURN_SUCCESS;
 }
@@ -47,11 +47,11 @@ AcpiPmControl (
   ASSERT (SuspendType < 6);
 
   AcpiPmBaseAddress = 0;
-  switch (mHostBridgeDevId) {
-  case INTEL_82441_DEVICE_ID:
+  switch (mOvmfMachineId) {
+  case X86_I440FX:
     AcpiPmBaseAddress = PIIX4_PMBA_VALUE;
     break;
-  case INTEL_Q35_MCH_DEVICE_ID:
+  case X86_Q35:
     AcpiPmBaseAddress = ICH9_PMBASE_VALUE;
     break;
   default:
@@ -112,8 +112,8 @@ ResetWarm (
   )
 {
 
-  switch (mHostBridgeDevId) {
-  case VIRT_QEMU_DEVICE_ID:
+  switch (mOvmfMachineId) {
+  case X86_VIRT:
     IoWrite8 (VIRT_RESET_ADDRESS, ACPI_REDUCED_RESET_VALUE);
     CpuDeadLoop ();
     break;
@@ -138,8 +138,8 @@ ResetShutdown (
   )
 {
 
-  switch (mHostBridgeDevId) {
-  case VIRT_QEMU_DEVICE_ID:
+  switch (mOvmfMachineId) {
+  case X86_VIRT:
     AcpiReducedSleepControl (ACPI_REDUCED_SLEEP_TYPE);
     break;
   default:

--- a/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -41,4 +41,4 @@
   TimerLib
 
 [Pcd]
-  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfMachineId

--- a/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/OvmfPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -19,6 +19,7 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = ResetSystemLib
+  CONSTRUCTOR                    = ResetSystemLibConstructor
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -36,5 +37,8 @@
 [LibraryClasses]
   DebugLib
   IoLib
-  PciLib
+  PcdLib
   TimerLib
+
+[Pcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -151,6 +151,11 @@
   #  This PCD is only accessed if PcdSmmSmramRequire is TRUE (see below).
   gUefiOvmfPkgTokenSpaceGuid.PcdQ35TsegMbytes|8|UINT16|0x20
 
+  ## The 16-bit MachineId indentifying the machine type
+  #  supplied by the hypervisor.
+  #
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfMachineId|0|UINT16|0x28
+
 [PcdsFeatureFlag]
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderPciTranslation|TRUE|BOOLEAN|0x1c
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuBootOrderMmioTranslation|FALSE|BOOLEAN|0x1d

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -543,6 +543,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|600
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable|FALSE
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId|0
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfMachineId|0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoBase|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoSize|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio32Base|0x0

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -548,7 +548,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|800
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|600
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable|FALSE
-  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId|0
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfMachineId|0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoBase|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoSize|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio32Base|0x0

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -547,7 +547,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|800
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|600
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable|FALSE
-  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId|0
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfMachineId|0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoBase|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoSize|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio32Base|0x0

--- a/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
+++ b/OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.c
@@ -29,6 +29,7 @@
 
 #include <Protocol/PciHotPlugInit.h>
 #include <Protocol/PciRootBridgeIo.h>
+#include "OvmfPlatforms.h"
 
 //
 // TRUE if the PCI platform supports extended config space, FALSE otherwise.
@@ -793,10 +794,11 @@ DriverInitialize (
   IN EFI_SYSTEM_TABLE *SystemTable
   )
 {
-  EFI_STATUS Status;
+  EFI_STATUS Status; 
+  UINT16 hostBridgeId = PcdGet16 (PcdOvmfHostBridgePciDevId);
 
-  mPciExtConfSpaceSupported = (PcdGet16 (PcdOvmfHostBridgePciDevId) ==
-                               INTEL_Q35_MCH_DEVICE_ID);
+  mPciExtConfSpaceSupported = ((hostBridgeId == INTEL_Q35_MCH_DEVICE_ID) ||
+	                       (hostBridgeId == VIRT_QEMU_DEVICE_ID));
 
   mPciHotPlugInit.GetRootHpcList = GetRootHpcList;
   mPciHotPlugInit.InitializeRootHpc = InitializeRootHpc;

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -640,6 +640,7 @@ InitializePlatform (
   )
 {
   EFI_STATUS    Status;
+  RETURN_STATUS PcdStatus;
 
   DEBUG ((DEBUG_INFO, "Platform PEIM Loaded\n"));
 
@@ -661,6 +662,9 @@ InitializePlatform (
 
   QemuFwCfgSelectItem (QemuFwCfgItemMachineId);
   mMachineId = QemuFwCfgRead16 ();
+
+  PcdStatus = PcdSet16S (PcdOvmfMachineId, mMachineId);
+  ASSERT_RETURN_ERROR (PcdStatus);
 
   switch (mMachineId) {
     case X86_I440FX:

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -81,6 +81,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfLockBoxStorageSize
   gUefiOvmfPkgTokenSpaceGuid.PcdGuidedExtractHandlerTableSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfMachineId
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoBase
   gUefiOvmfPkgTokenSpaceGuid.PcdPciIoSize
   gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio32Base


### PR DESCRIPTION
The virt platform supports PCI Express. Use MMIO to access the
PCI configuration space. This allows devices that are attached
to PCI Segment Groups (domains) to be used as boot devices.

Also eliminate the PCI reads from the ResetLibrary as the MCFG
is not mapped for EFI runtime access. Cache information from
the Pcd in the constructor. 

Introduce a new Pcd variable to store the machine id obtained from
fw_cfg.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>
